### PR TITLE
移除不必要的视频下载检查逻辑

### DIFF
--- a/src/DFApp.Application/Background/ListenTelegramService.cs
+++ b/src/DFApp.Application/Background/ListenTelegramService.cs
@@ -291,10 +291,6 @@ namespace DFApp.Background
             {
                 try
                 {
-                    if (!await StartDownloadVideo())
-                    {
-                        continue;
-                    }
                     var model = await queue.GetItemAsync(stoppingToken);
                     if (model == null)
                     {
@@ -393,16 +389,6 @@ namespace DFApp.Background
         {
             long size = await _mediaInfoRepository.GetDownloadsSize();
             return StorageUnitConversionHelper.ByteToMB((double)(size));
-        }
-
-        public async Task<bool> StartDownloadVideo()
-        {
-            await Task.Delay(2000);
-            if (DateTime.Now >= DateTimeHelper.GetTomorrowAtZero().AddHours(-9) && DateTime.Now <= DateTimeHelper.GetTomorrowAtZero().AddHours(-7))
-            {
-                return true;
-            }
-            return false;
         }
 
         public async Task IsUpperLimit()


### PR DESCRIPTION
- 删除`StartDownloadVideo`方法
- 移除对`StartDownloadVideo`的调用
- 简化主循环逻辑
- 提高代码可读性
- 减少不必要的延迟

Generated by DeepSeek