### PR TITLE
更新媒体信息DTO和前端表格排序逻辑

### DIFF
--- a/src/DFApp.Application.Contracts/Media/MediaInfoDto.cs
+++ b/src/DFApp.Application.Contracts/Media/MediaInfoDto.cs
@@ -5,7 +5,7 @@ namespace DFApp.Media
 {
     public class MediaInfoDto : AuditedEntityDto<long>
     {
-        public long MediaId { get; set; }
+        public string MediaId { get; set; } = null!;
         public long ChatId { get; set; }
         public string ChatTitle { get; set; } = null!;
         public string? Message { get; set; }

--- a/src/DFApp.Application/DFAppApplicationAutoMapperProfile.cs
+++ b/src/DFApp.Application/DFAppApplicationAutoMapperProfile.cs
@@ -21,7 +21,8 @@ public class DFAppApplicationAutoMapperProfile : Profile
 {
     public DFAppApplicationAutoMapperProfile()
     {
-        CreateMap<MediaInfo, MediaInfoDto>();
+        CreateMap<MediaInfo, MediaInfoDto>()
+        .ForMember(dest => dest.MediaId, opt => opt.MapFrom(src => src.MediaId.ToString()));
         CreateMap<CreateUpdateMediaInfoDto, MediaInfo>();
         CreateMap<MediaInfoDto, MediaInfo>();
         CreateMap<MediaInfoDto, CreateUpdateMediaInfoDto>();

--- a/src/DFApp.Web/Pages/TG/Media/Index.js
+++ b/src/DFApp.Web/Pages/TG/Media/Index.js
@@ -6,7 +6,7 @@ $(function () {
         abp.libs.datatables.normalizeConfiguration({
             serverSide: true,
             paging: true,
-            order: [[7, "desc"]],
+            order: [[6, "desc"]],
             scrollX: true,
             ajax: abp.libs.datatables.createAjax(dFApp.media.mediaInfo.getList),
             columnDefs: [
@@ -52,10 +52,6 @@ $(function () {
                     }
                 },
                 {
-                    title: l('Media:Column:MediaSavePath'),
-                    data: "savePath"
-                },
-                {
                     title: l('Media:Column:MD5'),
                     data: "mD5"
                 },
@@ -66,11 +62,6 @@ $(function () {
                 {
                     title: l('Media:Column:MediaCreationTime'),
                     data: "creationTime",
-                    dataFormat: "datetime"
-                },
-                {
-                    title: l('Media:Column:MediaLastModificationTime'),
-                    data: "lastModificationTime",
                     dataFormat: "datetime"
                 },
                 {


### PR DESCRIPTION
- 将MediaInfoDto的MediaId类型改为字符串
- 更新AutoMapper配置以映射MediaId
- 调整前端表格排序字段
- 移除未使用的表格列
- 简化前端表格列定义

Generated by DeepSeek