### PR TITLE
添加剩余磁盘空间显示功能

### DIFF
--- a/src/DFApp.Web/Pages/Index.cshtml
+++ b/src/DFApp.Web/Pages/Index.cshtml
@@ -25,6 +25,15 @@
             <a abp-button="Primary" href="~/Account/Login"><i class="fa fa-sign-in"></i> @L["Login"]</a>
         }
 
+        @if (CurrentUser.IsAuthenticated)
+        {
+            <!-- New Display Box for Remaining Disk Space -->
+            <div class="mt-4 p-3 bg-primary text-white rounded shadow-lg">
+                <h5 class="mb-0"><i class="fas fa-hdd"></i> Remaining Disk Space: <strong>@Model.RemainingDiskSpace</strong>
+                </h5>
+            </div>
+        }
+
     </div>
    
 </div>

--- a/src/DFApp.Web/Pages/Index.cshtml.cs
+++ b/src/DFApp.Web/Pages/Index.cshtml.cs
@@ -1,9 +1,29 @@
-﻿namespace DFApp.Web.Pages;
+﻿using System.Threading.Tasks;
+using DFApp.Configuration;
+using DFApp.Helper;
+
+namespace DFApp.Web.Pages;
 
 public class IndexModel : DFAppPageModel
 {
-    public void OnGet()
-    {
+    public string? RemainingDiskSpace { get; private set; }
 
+    private readonly ConfigurationInfoService _configurationInfoService;
+    public IndexModel(ConfigurationInfoService configurationInfoService)
+    {
+        _configurationInfoService = configurationInfoService;
     }
+
+    public async Task OnGetAsync()
+    {
+        RemainingDiskSpace = await GetRemainingDiskSpaceAsync();
+    }
+
+    private async Task<string> GetRemainingDiskSpaceAsync()
+    {
+        string SaveDrive = await _configurationInfoService.GetConfigurationInfoValue("SaveDrive",string.Empty);
+        return StorageUnitConversionHelper.ByteToGB(SpaceHelper.GetAnyDriveAvailable(SaveDrive)).ToString("F2") + "GB";
+    }
+
+
 }

--- a/src/DFApp.Web/Pages/Index.css
+++ b/src/DFApp.Web/Pages/Index.css
@@ -1,3 +1,24 @@
 body {
-    
+
+    /* Index.css */
+    .bg-primary {
+        background-color: #007bff !important;
+    }
+
+    .shadow-lg {
+        box-shadow: 0 1rem 3rem rgba(0, 0, 0, .175) !important;
+    }
+
+    .rounded {
+        border-radius: .25rem !important;
+    }
+
+    .p-3 {
+        padding: 1rem !important;
+    }
+
+    .mb-0 {
+        margin-bottom: 0 !important;
+    }
+
 }


### PR DESCRIPTION
- 在首页添加剩余磁盘空间显示框
- 实现获取剩余磁盘空间逻辑
- 更新样式以支持新显示框
- 注入配置服务以获取磁盘信息
- 使用辅助类进行单位转换

Generated by DeepSeek