### PR TITLE
fix(background): 添加异常捕获，确保单个彩票处理失败不影响其他

### DIFF
--- a/src/DFApp.Application/Background/LotteryResultTimer.cs
+++ b/src/DFApp.Application/Background/LotteryResultTimer.cs
@@ -57,8 +57,25 @@ namespace DFApp.Background
 
         public override async Task Execute(IJobExecutionContext context)
         {
-            await StartWork(LotteryConst.SSQ, LotteryConst.SSQ_ENG, LotteryConst.SSQ_START_CODE);
-            await StartWork(LotteryConst.KL8, LotteryConst.KL8_ENG, LotteryConst.KL8_STRAT_CODE);
+            // 处理双色球（SSQ），失败不影响其他彩票类型
+            try
+            {
+                await StartWork(LotteryConst.SSQ, LotteryConst.SSQ_ENG, LotteryConst.SSQ_START_CODE);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, $"处理双色球(SSQ)时发生异常，将继续处理其他彩票类型");
+            }
+
+            // 处理快乐8（KL8），失败不影响其他彩票类型
+            try
+            {
+                await StartWork(LotteryConst.KL8, LotteryConst.KL8_ENG, LotteryConst.KL8_STRAT_CODE);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, $"处理快乐8(KL8)时发生异常，将继续处理其他彩票类型");
+            }
         }
 
         private async Task StartWork(string lotteryType, string lotteryTypeEng, string code)


### PR DESCRIPTION
在 LotteryResultTimer 的 Execute 方法中为双色球(SSQ)和快乐8(KL8) 的处理逻辑分别添加 try-catch 异常捕获块。当某种彩票类型处理
发生异常时，仅记录错误日志而不中断整个任务，从而保证其他彩票
类型能继续正常处理。