### PR TITLE
fix: 修复 PrizegradesItemDto.Type 的 JsonConverter 运行时类型不兼容

### DIFF
--- a/src/DFApp.Web/DTOs/Lottery/PrizegradesItemDto.cs
+++ b/src/DFApp.Web/DTOs/Lottery/PrizegradesItemDto.cs
@@ -7,7 +7,7 @@ namespace DFApp.Web.DTOs.Lottery
     {
 
         [JsonPropertyName("type")]
-        [JsonConverter(typeof(IntToStringConverter))]
+        [JsonConverter(typeof(FlexibleStringConverter))]
         public string? Type { get; set; }
 
         [JsonPropertyName("typenum")]

--- a/src/DFApp.Web/Infrastructure/FlexibleStringConverter.cs
+++ b/src/DFApp.Web/Infrastructure/FlexibleStringConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DFApp.Web.Infrastructure
+{
+    /// <summary>
+    /// 灵活的字符串转换器，能将 JSON 中的数字和字符串都转换为 C# string
+    /// </summary>
+    public class FlexibleStringConverter : JsonConverter<string?>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+                return reader.GetString();
+            if (reader.TokenType == JsonTokenType.Number)
+                return reader.GetInt32().ToString();
+            if (reader.TokenType == JsonTokenType.Null)
+                return null;
+            throw new JsonException($"意外的 JSON 令牌类型: {reader.TokenType}，期望字符串、数字或null。");
+        }
+
+        public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+}


### PR DESCRIPTION
- IntToStringConverter 继承 JsonConverter<int> 但 Type 属性是 string 类型，运行时报错
- 创建 FlexibleStringConverter (JsonConverter<string?>) 替代，支持 JSON Number/String/Null 统一转为 string