### PR TITLE
fix: 修复 RSS 镜像条目分页无效和下载失败问题

### DIFF
--- a/client/src/api/rssMirror.ts
+++ b/client/src/api/rssMirror.ts
@@ -15,7 +15,21 @@ class RssMirrorApi {
   async getList(
     input: GetRssMirrorItemsRequestDto
   ): Promise<PagedResultDto<RssMirrorItemDto>> {
-    return http.get(this.baseUrl, { params: input });
+    const pageIndex = input?.pageIndex ?? 1;
+    const pageSize = input?.pageSize ?? 10;
+    return http.get(this.baseUrl, {
+      params: {
+        skipCount: (pageIndex - 1) * pageSize,
+        maxResultCount: pageSize,
+        sorting: input?.sorting,
+        rssSourceId: input?.rssSourceId,
+        filter: input?.filter,
+        startTime: input?.startTime,
+        endTime: input?.endTime,
+        isDownloaded: input?.isDownloaded,
+        wordToken: input?.wordToken
+      }
+    });
   }
 
   /**
@@ -59,8 +73,15 @@ class RssMirrorApi {
     wordToken: string,
     params?: PagedRequestDto
   ): Promise<PagedResultDto<RssMirrorItemDto>> {
+    const pageIndex = params?.pageIndex ?? 1;
+    const pageSize = params?.pageSize ?? 10;
     return http.get(`${this.baseUrl}/by-word-token`, {
-      params: { wordToken, ...params }
+      params: {
+        wordToken,
+        skipCount: (pageIndex - 1) * pageSize,
+        maxResultCount: pageSize,
+        sorting: params?.sorting
+      }
     });
   }
 

--- a/src/DFApp.Web/Services/Rss/RssMirrorItemAppService.cs
+++ b/src/DFApp.Web/Services/Rss/RssMirrorItemAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DFApp.Rss;
+using DFApp.Aria2;
 using DFApp.Web.Data;
 using DFApp.Web.DTOs;
 using DFApp.Web.DTOs.Rss;
@@ -22,9 +23,7 @@ public class RssMirrorItemAppService : AppServiceBase
     private readonly ISqlSugarRepository<RssWordSegment, long> _rssWordSegmentRepository;
     private readonly ISqlSugarRepository<RssSource, long> _rssSourceRepository;
     private readonly ILogger<RssMirrorItemAppService> _logger;
-
-    // TODO: IAria2Service 未迁移，暂时使用 object? 替代
-    private readonly object? _aria2Service;
+    private readonly Services.Aria2.Aria2Service _aria2Service;
 
     /// <summary>
     /// 构造函数
@@ -34,6 +33,7 @@ public class RssMirrorItemAppService : AppServiceBase
     /// <param name="rssMirrorItemRepository">RSS镜像条目仓储</param>
     /// <param name="rssWordSegmentRepository">RSS分词仓储</param>
     /// <param name="rssSourceRepository">RSS源仓储</param>
+    /// <param name="aria2Service">Aria2下载服务</param>
     /// <param name="logger">日志记录器</param>
     public RssMirrorItemAppService(
         ICurrentUser currentUser,
@@ -41,12 +41,14 @@ public class RssMirrorItemAppService : AppServiceBase
         ISqlSugarRepository<RssMirrorItem, long> rssMirrorItemRepository,
         ISqlSugarRepository<RssWordSegment, long> rssWordSegmentRepository,
         ISqlSugarRepository<RssSource, long> rssSourceRepository,
+        Services.Aria2.Aria2Service aria2Service,
         ILogger<RssMirrorItemAppService> logger)
         : base(currentUser, permissionChecker)
     {
         _rssMirrorItemRepository = rssMirrorItemRepository;
         _rssWordSegmentRepository = rssWordSegmentRepository;
         _rssSourceRepository = rssSourceRepository;
+        _aria2Service = aria2Service;
         _logger = logger;
     }
 
@@ -301,25 +303,29 @@ public class RssMirrorItemAppService : AppServiceBase
             throw new BusinessException("该条目已经下载过");
         }
 
-        // TODO: IAria2Service 未迁移，以下为伪代码
-        // var request = new AddDownloadRequestDto
-        // {
-        //     Urls = new List<string> { item.Link },
-        //     VideoOnly = videoOnly,
-        //     EnableKeywordFilter = enableKeywordFilter
-        // };
-        // var result = await _aria2Service.AddDownloadAsync(request);
+        if (string.IsNullOrWhiteSpace(item.Link))
+        {
+            throw new BusinessException("该条目没有下载链接");
+        }
 
-        // 更新下载状态
+        // 构造下载请求，先调用 Aria2 添加下载任务
+        var request = new AddDownloadRequestDto
+        {
+            Urls = new List<string> { item.Link },
+            VideoOnly = videoOnly,
+            EnableKeywordFilter = enableKeywordFilter
+        };
+
+        var result = await _aria2Service.AddDownloadAsync(request);
+
+        // 下载任务创建成功后才更新下载状态
         item.IsDownloaded = true;
         item.DownloadTime = DateTime.Now;
         await _rssMirrorItemRepository.UpdateAsync(item);
 
-        _logger.LogInformation("RSS镜像条目 {Id} 已添加到Aria2下载队列", id);
+        _logger.LogInformation("RSS镜像条目 {Id} 已添加到Aria2下载队列，GID: {Gid}", id, result.Id);
 
-        // TODO: IAria2Service 未迁移，返回占位值
-        throw new BusinessException("IAria2Service 尚未迁移，下载功能暂不可用");
-        // return result.Id;
+        return result.Id;
     }
 
     /// <summary>


### PR DESCRIPTION
问题1 - 分页无效：
- 前端 API 调用使用 pageIndex/pageSize 参数名
- 后端期望 skipCount/maxResultCount 参数名
- 在 API 层添加参数转换逻辑

问题2 - 下载失败(400错误)：
- RssMirrorItemAppService.DownloadToAria2Async 为 TODO 伪代码
- 注入真正的 Aria2Service 实现下载功能
- 修复 IsDownloaded 状态更新时机（成功后才标记）