### PR TITLE
fix: 修复 aria2.addTorrent 参数顺序错误

### DIFF
--- a/src/DFApp.Web/Domain/Aria2/Aria2RpcClient.cs
+++ b/src/DFApp.Web/Domain/Aria2/Aria2RpcClient.cs
@@ -282,7 +282,9 @@ public class Aria2RpcClient
     /// </summary>
     public async Task<string> AddTorrentAsync(string torrentData, Dictionary<string, object>? options = null)
     {
-        var parameters = new List<object?> { torrentData };
+        // aria2.addTorrent 参数顺序: [secret, ] torrentData [, uris [, options]]
+        // 必须提供 uris 占位参数，否则 options 会被错误地解析为 uris 类型
+        var parameters = new List<object?> { torrentData, new List<string>() };
         if (options != null && options.Count > 0)
         {
             parameters.Add(options);


### PR DESCRIPTION
aria2.addTorrent 的参数顺序为 [secret,] torrentData [, uris [, options]] 缺少 uris 参数占位导致 options 字典被放到 uris 位置，类型不匹配