### PR TITLE
fix: RSS镜像条目分页改10条、下载超时30秒、修复task-detail 404

### DIFF
--- a/client/src/api/aria2.ts
+++ b/client/src/api/aria2.ts
@@ -74,7 +74,7 @@ class Aria2Api {
   async addDownload(
     request: AddDownloadRequestDto
   ): Promise<AddDownloadResponseDto> {
-    return http.post(`${this.baseUrl}/add-download`, { data: request });
+    return http.post(`${this.baseUrl}/add-download`, { data: request, timeout: 30000 });
   }
 
   // ============ Aria2 管理相关 API (直接连接 aria2 RPC) ============
@@ -116,46 +116,42 @@ class Aria2Api {
    * 获取任务状态
    */
   async getTaskStatus(gid: string): Promise<Aria2TaskDto> {
-    return http.get(`${this.manageUrl}/task-status`, {
-      params: { gid }
-    });
+    return http.get(`${this.manageUrl}/task-status/${gid}`);
   }
 
   /**
    * 获取任务详情（包含peers和文件列表）
    */
   async getTaskDetail(gid: string): Promise<Aria2TaskDetailDto> {
-    return http.get(`${this.manageUrl}/task-detail`, {
-      params: { gid }
-    });
+    return http.get(`${this.manageUrl}/task-detail/${gid}`);
   }
 
   /**
    * 添加 URI 下载任务
    */
   async addUri(request: AddDownloadRequestDto): Promise<string> {
-    return http.post(`${this.manageUrl}/add-uri`, { data: request });
+    return http.post(`${this.manageUrl}/add-uri`, { data: request, timeout: 30000 });
   }
 
   /**
    * 批量添加 URI 下载任务（每条链接创建独立任务）
    */
   async batchAddUri(request: BatchAddUriRequestDto): Promise<string[]> {
-    return http.post(`${this.manageUrl}/batch-add-uri`, { data: request });
+    return http.post(`${this.manageUrl}/batch-add-uri`, { data: request, timeout: 30000 });
   }
 
   /**
    * 添加种子文件下载任务
    */
   async addTorrent(request: AddTorrentRequestDto): Promise<string> {
-    return http.post(`${this.manageUrl}/add-torrent`, { data: request });
+    return http.post(`${this.manageUrl}/add-torrent`, { data: request, timeout: 30000 });
   }
 
   /**
    * 批量添加种子文件下载任务
    */
   async batchAddTorrent(request: BatchAddTorrentRequestDto): Promise<string[]> {
-    return http.post(`${this.manageUrl}/batch-add-torrent`, { data: request });
+    return http.post(`${this.manageUrl}/batch-add-torrent`, { data: request, timeout: 30000 });
   }
 
   /**

--- a/client/src/api/rssMirror.ts
+++ b/client/src/api/rssMirror.ts
@@ -101,7 +101,8 @@ class RssMirrorApi {
     enableKeywordFilter: boolean = false
   ): Promise<string> {
     return http.post(`${this.baseUrl}/${id}/download-to-aria2`, {
-      params: { videoOnly, enableKeywordFilter }
+      params: { videoOnly, enableKeywordFilter },
+      timeout: 30000
     });
   }
 }

--- a/client/src/views/rss-mirror/items/index.vue
+++ b/client/src/views/rss-mirror/items/index.vue
@@ -322,7 +322,7 @@ const dateRange = ref<[string, string]>([]);
 // 分页
 const pagination = reactive({
   page: 1,
-  pageSize: 20,
+  pageSize: 10,
   total: 0
 });
 


### PR DESCRIPTION
- 分页默认条数从20改为10
- 所有下载相关请求超时从10秒改为30秒
- getTaskStatus/getTaskDetail 改用路由参数匹配后端