### PR TITLE
fix: 修复 IP 地理信息查询参数格式不匹配

### DIFF
--- a/client/src/api/aria2.ts
+++ b/client/src/api/aria2.ts
@@ -215,7 +215,7 @@ class Aria2Api {
    */
   async getIpGeolocation(ips: string[]): Promise<IpGeolocationDto[]> {
     return http.post(`${this.manageUrl}/ip-geolocation`, {
-      data: { Ips: ips }
+      data: ips
     });
   }
 }


### PR DESCRIPTION
前端将 IP 数组包装在对象中发送，后端期望纯数组，导致 400